### PR TITLE
Update .gitignore to avoid not including change in _sass/vendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,8 @@ Gemfile.lock
 node_modules
 package-lock.json
 
-# Ignore the vendor file and bundle for alternative installation
-vendor/
+# Ignore the vendor file at root level and bundle for alternative installation
+/vendor/
 .bundle/
 
 # Ignore folders related to IDEs


### PR DESCRIPTION
On line 16 ``vendor/`` would lead to any change in the ``_sass/vendor`` folder to also be ignored. This can lead to a missing import packages error during page build on the GitHub page actions if the user manually copies the project source code to their repository.